### PR TITLE
Cmd database import

### DIFF
--- a/src/Robo/Plugin/Commands/ImportDBCommand.php
+++ b/src/Robo/Plugin/Commands/ImportDBCommand.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Fire\Robo\Plugin\Commands;
+
+use Robo\Symfony\ConsoleIO;
+use Robo\Robo;
+use Robo\Tasks;
+
+/**
+ * Provides a Import database command.
+ */
+class ImportDBCommand extends Tasks {
+
+  /**
+   * Import database for local envs.
+   *
+   * Usage Example: fire import-db -- <database-file>.sql.gz
+   *
+   * @command local:import-db
+   * @aliases import-db
+   * @usage -- <database-file>.sql.gz
+   *
+   * @param $args drush you would like to execute.
+   */
+  public function import_db(ConsoleIO $io, array $args) {
+    return $this->run($io, $args);
+  }
+
+  /**
+   * Import database for local envs.
+   *
+   * Usage Example: fire db-import -- <database-file>.sql.gz
+   *
+   * @command local:db-import
+   * @aliases db-import
+   * @usage -- <database-file>.sql.gz
+   *
+   * @param $args drush you would like to execute.
+   */
+  public function db_import(ConsoleIO $io, array $args) {
+    return $this->run($io, $args);
+  }
+
+  /**
+   * Run both commands.
+   */
+  public function run(ConsoleIO $io, array $args) {
+    $cmd = ''; 
+    $env = Robo::config()->get('environment');
+
+    switch ($env) {
+      case 'lando':
+      default:
+        $cmd = 'db-import'; 
+        break;
+      case 'ddev':
+        $cmd = 'import-db --src='; 
+        break;
+    }
+
+    $tasks = $this->collectionBuilder($io);
+    $tasks->addTask($this->taskExec("$env  $cmd")->args($args));
+    return $tasks;
+  }
+}

--- a/src/Robo/Plugin/Commands/ImportDBCommand.php
+++ b/src/Robo/Plugin/Commands/ImportDBCommand.php
@@ -30,27 +30,31 @@ class ImportDBCommand extends Tasks {
    * Run both commands.
    */
   public function run(ConsoleIO $io, array $args) {
-    $cmd = ''; 
-    $env = Robo::config()->get('environment');
+    $cmd = '';
+    $env = Robo::config()->get('local_environment');
 
-    if (count($args) < 1) {
-      return "You need to write the name of the database. Example: 'fire db-import -- site-db.sql.gz'";
+    if (!count($args)) {
+      $args[0] = 'site-db.sql.gz';
+    }
+
+    if (!file_exists($args[0])) {
+      return "The specified file doesn't exist, please provide a file, example: 'fire db-import -- site-db.sql.gz'";
     }
 
     switch ($env) {
       case 'lando':
       default:
-        $cmd = "db-import ";
+        $cmd = "lando db-import";
         break;
       case 'ddev':
         $db_name = $args[0];
         unset($args[0]);
-        $cmd = "import-db --src=$db_name ";
+        $cmd = "ddev import-db --src=$db_name ";
         break;
     }
 
     $tasks = $this->collectionBuilder($io);
-    $tasks->addTask($this->taskExec("$env $cmd")->args($args));
+    $tasks->addTask($this->taskExec($cmd)->args($args));
 
     return $tasks;
   }

--- a/src/Robo/Plugin/Commands/ImportDBCommand.php
+++ b/src/Robo/Plugin/Commands/ImportDBCommand.php
@@ -17,27 +17,12 @@ class ImportDBCommand extends Tasks {
    * Usage Example: fire import-db -- <database-file>.sql.gz
    *
    * @command local:import-db
-   * @aliases import-db
+   * @aliases import-db, db-import, importdb, dbimport, import_db, db_import
    * @usage -- <database-file>.sql.gz
    *
    * @param $args drush you would like to execute.
    */
   public function import_db(ConsoleIO $io, array $args) {
-    return $this->run($io, $args);
-  }
-
-  /**
-   * Import database for local envs.
-   *
-   * Usage Example: fire db-import -- <database-file>.sql.gz
-   *
-   * @command local:db-import
-   * @aliases db-import
-   * @usage -- <database-file>.sql.gz
-   *
-   * @param $args drush you would like to execute.
-   */
-  public function db_import(ConsoleIO $io, array $args) {
     return $this->run($io, $args);
   }
 
@@ -48,18 +33,26 @@ class ImportDBCommand extends Tasks {
     $cmd = ''; 
     $env = Robo::config()->get('environment');
 
+    if (count($args) < 1) {
+      return "You need to write the name of the database. Example: 'fire db-import -- site-db.sql.gz'";
+    }
+
     switch ($env) {
       case 'lando':
       default:
-        $cmd = 'db-import'; 
+        $cmd = "db-import ";
         break;
       case 'ddev':
-        $cmd = 'import-db --src='; 
+        $db_name = $args[0];
+        unset($args[0]);
+        $cmd = "import-db --src=$db_name ";
         break;
     }
 
     $tasks = $this->collectionBuilder($io);
-    $tasks->addTask($this->taskExec("$env  $cmd")->args($args));
+    $tasks->addTask($this->taskExec("$env $cmd")->args($args));
+
     return $tasks;
   }
+
 }


### PR DESCRIPTION
## Description:

- Implements a new command to import the database.
- Delete a duplicated function and use aliases instead of two functions.
- Fix a bug with ddev command.

## Steps to test:

- [ ] Install fire into your project: `composer require "fourkitchens/fire:dev-feature/cmd-database-import" --ignore-platform-reqs`
- [ ] Run the command: `fire import-db -- <your-project-db>.sql.gz` or `fire db-import -- <your-project-db>.sql.gz` and check everything works fine.