### PR TITLE
Build get files command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ Example:
 - local:configure:export  [configure-export|configure_export|cex] Export config.
 - local:configure:import  [configure-import|configure_import|cim] Import config.
 - local:drush             [drush] Drush proxy for local envs.
-- local:get-db            [get-db|db-get|getdb|dbget|get_db|db_get|local:db:get|local:get:db] Import database for local envs.
+- local:get-db            [get-db|db-get|getdb|dbget|get_db|db_get|local:db:get|local:get:db] Get the database from remote site.
+- local:get-files         [get-files|files-get|getfiles|filesget|get_files|files_get|pull-files|pull_files|local:files:get|local:get:files] Get files from remote site and put in the local env.
 - local:import-db         [import-db|db-import|importdb|dbimport|import_db|db_import] Import database for - local envs.
 - local:build:theme       [build-theme] Builds Projects theme.
 - local:build             [local-build|build] Builds your Drupal Site from the scratch.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Example:
 - local:configure:import  [configure-import|configure_import|cim] Import config.
 - local:drush             [drush] Drush proxy for local envs.
 - local:get-db            [get-db|db-get|getdb|dbget|get_db|db_get|local:db:get|local:get:db] Get the database from remote site.
-- local:get-files         [get-files|files-get|getfiles|filesget|get_files|files_get|pull-files|pull_files|local:files:get|local:get:files] Get files from remote site and put in the local env.
+- local:get-files         [get-files|files-get|getfiles|filesget|get_files|files_get|pull-files|pull_files|local:files:get|local:get:files] Downloads the sites files from the remote source (Pantheon, acquia).
 - local:import-db         [import-db|db-import|importdb|dbimport|import_db|db_import] Import database for - local envs.
 - local:build:theme       [build-theme] Builds Projects theme.
 - local:build             [local-build|build] Builds your Drupal Site from the scratch.

--- a/src/Robo/Plugin/Commands/GetFilesCommand.php
+++ b/src/Robo/Plugin/Commands/GetFilesCommand.php
@@ -11,7 +11,7 @@ use Robo\Robo;
 class GetFilesCommand extends FireCommandBase {
 
   /**
-   * Import database for local envs.
+   * Downloads the sites files from the remote source (Pantheon, acquia).
    *
    * Usage Example: fire local:files:get
    *

--- a/src/Robo/Plugin/Commands/GetFilesCommand.php
+++ b/src/Robo/Plugin/Commands/GetFilesCommand.php
@@ -16,7 +16,7 @@ class GetFilesCommand extends FireCommandBase {
    * Usage Example: fire local:files:get
    *
    * @command local:get-files
-   * @aliases get-files, files-get, getfiles, filesget, get_files, files_get, pull-files, pull_files, local:file:get, local:get:files
+   * @aliases get-files, files-get, getfiles, filesget, get_files, files_get, pull-files, pull_files, local:files:get, local:get:files
    * @usage fire local:files:get
    *
    * @param $args drush you would like to execute.

--- a/src/Robo/Plugin/Commands/GetFilesCommand.php
+++ b/src/Robo/Plugin/Commands/GetFilesCommand.php
@@ -18,9 +18,10 @@ class GetFilesCommand extends FireCommandBase {
    * @command local:get-files
    * @aliases get-files, files-get, getfiles, filesget, get_files, files_get, pull-files, pull_files, local:file:get, local:get:files
    * @usage fire local:files:get
-   * @option $no-overwrite If the value is TRUE, checks if the files exists and they are no downloaded again.
+   * @option $no-download Reuse your existing files copy in the reference folder and placing them in the files folder (Pantheon only).
    */
-  public function getFiles(ConsoleIO $io, $opts = ['no-overwrite' => FALSE]) {
+  public function getFiles(ConsoleIO $io, $opts = ['no-download' => FALSE]) {
+    $tasks = $this->collectionBuilder($io);
     $remotePlatform = Robo::config()->get('remote_platform');
     $remoteSiteName = Robo::config()->get('remote_sitename');
     $remoteEnv = Robo::config()->get('remote_canonical_env');
@@ -29,16 +30,27 @@ class GetFilesCommand extends FireCommandBase {
 
     // Create the folder.
     if (!file_exists($origFilesFolder)) {
-      $this->_mkdir($origFilesFolder);
+      $tasks->addTask($this->taskFilesystemStack()->mkdir($origFilesFolder));
+    }
+
+    // Creating files the folder if not exists.
+    if (!file_exists($destFilesFolder)) {
+      $this->taskFilesystemStack()->mkdir($destFilesFolder);
+    }
+    else {
+      // Removing all existing files from files folder.
+      if ($remotePlatform == 'pantheon') {
+        $tasks->addTask($this->taskCleanDir($destFilesFolder));
+      }
     }
 
     switch ($remotePlatform) {
       case 'acquia':
-        $tasks = $this->getFilesAcquia($io, $opts, $remotePlatform, $remoteSiteName, $remoteEnv, $origFilesFolder, $destFilesFolder);
+        $tasks = $this->getFilesAcquia($io, $tasks, $remoteSiteName, $remoteEnv);
         break;
       case 'pantheon':
       default:
-        $tasks = $this->getFilesPantheon($io, $opts, $remotePlatform, $remoteSiteName, $remoteEnv, $origFilesFolder, $destFilesFolder);
+        $tasks = $this->getFilesPantheon($io, $opts, $tasks, $remoteSiteName, $remoteEnv, $origFilesFolder, $destFilesFolder);
         break;
     }
 
@@ -48,59 +60,42 @@ class GetFilesCommand extends FireCommandBase {
   /**
    * Helper function to get files from Acquia.
    */
-  private function getFilesAcquia(ConsoleIO $io, array $opts, $remotePlatform, $remoteSiteName, $remoteEnv, $origFilesFolder, $destFilesFolder) {
-    $tasks = $this->collectionBuilder($io);
-
-    if ($this->getCliToolStatus('acli')) {
-      $uploadFolder = 'docroot';
-      if (!$opts['no-overwrite']) {
-        $cmd = "cd $origFilesFolder";
-        $cmd .= " && acli pull:files $remoteSiteName.$remoteEnv default";
-        $cmd .= " && tar czvf $uploadFolder.tar.gz $uploadFolder";
-        $this->taskExec($cmd)->run();
-      }
-
-      if (file_exists("$origFilesFolder/$uploadFolder.tar.gz")) {
-        if (!file_exists("$origFilesFolder/$uploadFolder")) {
-          $this->taskExec("cd $origFilesFolder && tar xzvf $uploadFolder.tar.gz")->run();
-        }
-
-        $tasks->addTask($this->taskExec("cp -a $origFilesFolder/$uploadFolder/sites/default/files/* $destFilesFolder"));
-        $tasks->addTask($this->taskExec("chmod -R 775 $origFilesFolder/$uploadFolder"));
-        $tasks->addTask($this->taskExec("rm -r $origFilesFolder/$uploadFolder"));
+  private function getFilesAcquia(ConsoleIO $io, $tasks, $remoteSiteName, $remoteEnv) {
+    /**
+     * Acquia CLI will automatically placed all files under docroot/sites/default/files.`
+     */
+    if (file_exists($this->getLocalEnvRoot() . '/docroot/sites/default/files')) {
+      if ($this->getCliToolStatus('acli')) {
+          $io->say('Syncing files from the ' . $remoteEnv . ' environment...');
+          $cmd = 'cd ' . $this->getLocalEnvRoot();
+          $cmd .= ' && acli pull:files ' . $remoteSiteName . '.' . $remoteEnv . ' default';
+          $tasks->addTask($this->taskExec($cmd));
       }
       else {
-        return "The folder '$uploadFolder' doesn't exist.";
+        return 'Acquia CLI is not installed, please install and configure it: https://docs.acquia.com/acquia-cli/install/';
       }
     }
     else {
-      return 'Acquia CLI is not installed, please install and configure it: https://docs.acquia.com/acquia-cli/install/';
+      return 'Your Local env doesnt have a valid acquia project structure, your drupal root should be the "docroot" folder.';
     }
-
     return $tasks;
   }
 
   /**
    * Helper function to get files from Pantheon.
    */
-  private function getFilesPantheon(ConsoleIO $io, array $opts, $remotePlatform, $remoteSiteName, $remoteEnv, $origFilesFolder, $destFilesFolder) {
-    $tasks = $this->collectionBuilder($io);
+  private function getFilesPantheon(ConsoleIO $io, array $opts, $tasks, $remoteSiteName, $remoteEnv, $origFilesFolder, $destFilesFolder) {
 
     if ($this->getCliToolStatus('terminus')) {
       $filesName = 'site-files.tar.gz';
-      if (!$opts['no-overwrite']) {
+      if (!$opts['no-download']) {
         $cmd = "wget `terminus backup:get $remoteSiteName.$remoteEnv --element=files` -O $origFilesFolder/$filesName";
-        $this->taskExec($cmd)->run();
+        $tasks->addTask($this->taskExec($cmd));
       }
-
-      if (file_exists("$origFilesFolder/$filesName")) {
-        $tasks->addTask($this->taskExec("cd $origFilesFolder && tar xzvf $filesName"));
-        $tasks->addTask($this->taskExec("cp -a $origFilesFolder/files_$remoteEnv/* $destFilesFolder"));
-        $tasks->addTask($this->taskExec("rm -r $origFilesFolder/files_$remoteEnv"));
-      }
-      else {
-        return "The file '$filesName' doesn't exist.";
-      }
+      $tasks->addTask($this->taskFilesystemStack()->mkdir($origFilesFolder . '/files_' . $remoteEnv));
+      $tasks->addTask($this->taskExec('tar xzvf ' . $origFilesFolder . '/' . $filesName . ' -C ' . $origFilesFolder . '/files_' . $remoteEnv));
+      $tasks->addTask($this->taskCopyDir([$origFilesFolder . '/files_' . $remoteEnv => $destFilesFolder]));
+      $tasks->addTask($this->taskDeleteDir($origFilesFolder . '/files_' . $remoteEnv));
     }
     else {
       return 'Terminus is not installed, please install and configure it: https://docs.pantheon.io/terminus/install';

--- a/src/Robo/Plugin/Commands/GetFilesCommand.php
+++ b/src/Robo/Plugin/Commands/GetFilesCommand.php
@@ -11,60 +11,100 @@ use Robo\Robo;
 class GetFilesCommand extends FireCommandBase {
 
   /**
-   * Get files from remote site and put in the local env.
+   * Import database for local envs.
    *
    * Usage Example: fire local:files:get
    *
    * @command local:get-files
-   * @aliases get-files, files-get, getfiles, filesget, get_files, files_get, pull-files, pull_files, local:files:get, local:get:files
+   * @aliases get-files, files-get, getfiles, filesget, get_files, files_get, pull-files, pull_files, local:file:get, local:get:files
    * @usage fire local:files:get
-   *
-   * @param $args drush you would like to execute.
+   * @option $no-overwrite If the value is TRUE, checks if the files exists and they are no downloaded again.
    */
-  public function getFiles(ConsoleIO $io, array $args) {
-    $cmd = '';
+  public function getFiles(ConsoleIO $io, $opts = ['no-overwrite' => FALSE]) {
     $remotePlatform = Robo::config()->get('remote_platform');
     $remoteSiteName = Robo::config()->get('remote_sitename');
     $remoteEnv = Robo::config()->get('remote_canonical_env');
     $origFilesFolder = $this->getlocalEnvRoot() . '/reference';
     $destFilesFolder = $this->getDrupalRoot() . '/sites/default/files';
-    $tasks = $this->collectionBuilder($io);
 
+    // Create the folder.
     if (!file_exists($origFilesFolder)) {
-      $tasks->addTask($this->_mkdir($origFilesFolder));
+      $this->_mkdir($origFilesFolder);
     }
 
     switch ($remotePlatform) {
       case 'acquia':
-        if ($this->getCliToolStatus('acli')) {
-          $cmd = "cd $origFilesFolder";
-          $cmd .= " && acli pull:files $remoteSiteName.$remoteEnv default";
-          $cmd .= " && cp -a ./docroot/sites/default/files/* $destFilesFolder";
-          $cmd .= " && rm -r ./docroot";
-          $cmd .= " && cd ../";
-        }
-        else {
-          return 'Acquia CLI is not installed, please install and configure it: https://docs.acquia.com/acquia-cli/install/';
-        }
+        $tasks = $this->getFilesAcquia($io, $opts, $remotePlatform, $remoteSiteName, $remoteEnv, $origFilesFolder, $destFilesFolder);
         break;
       case 'pantheon':
       default:
-        if ($this->getCliToolStatus('terminus')) {
-          $filesName = 'site-files.tar.gz';
-
-          $cmd = "cd $origFilesFolder";
-          $cmd .= " && wget `terminus backup:get $remoteSiteName.$remoteEnv --element=files` -O $filesName";
-          $cmd .= " && tar xzvf $filesName";
-          $cmd .= " && cp -a files_$remoteEnv/* $destFilesFolder";
-          $cmd .= " && rm -r files_$remoteEnv";
-          $cmd .= " && cd ../";
-        }
-        else {
-          return 'Terminus is not installed, please install and configure it: https://docs.pantheon.io/terminus/install';
-        }
+        $tasks = $this->getFilesPantheon($io, $opts, $remotePlatform, $remoteSiteName, $remoteEnv, $origFilesFolder, $destFilesFolder);
         break;
     }
-    $tasks->addTask($this->taskExec("$cmd")->args($args));
+
+    return $tasks;
+  }
+
+  /**
+   * Helper function to get files from Acquia.
+   */
+  private function getFilesAcquia(ConsoleIO $io, array $opts, $remotePlatform, $remoteSiteName, $remoteEnv, $origFilesFolder, $destFilesFolder) {
+    $tasks = $this->collectionBuilder($io);
+
+    if ($this->getCliToolStatus('acli')) {
+      $uploadFolder = 'docroot';
+      if (!$opts['no-overwrite']) {
+        $cmd = "cd $origFilesFolder";
+        $cmd .= " && acli pull:files $remoteSiteName.$remoteEnv default";
+        $cmd .= " && tar czvf $uploadFolder.tar.gz $uploadFolder";
+        $this->taskExec($cmd)->run();
+      }
+
+      if (file_exists("$origFilesFolder/$uploadFolder.tar.gz")) {
+        if (!file_exists("$origFilesFolder/$uploadFolder")) {
+          $this->taskExec("cd $origFilesFolder && tar xzvf $uploadFolder.tar.gz")->run();
+        }
+
+        $tasks->addTask($this->taskExec("cp -a $origFilesFolder/$uploadFolder/sites/default/files/* $destFilesFolder"));
+        $tasks->addTask($this->taskExec("chmod -R 775 $origFilesFolder/$uploadFolder"));
+        $tasks->addTask($this->taskExec("rm -r $origFilesFolder/$uploadFolder"));
+      }
+      else {
+        return "The folder '$uploadFolder' doesn't exist.";
+      }
+    }
+    else {
+      return 'Acquia CLI is not installed, please install and configure it: https://docs.acquia.com/acquia-cli/install/';
+    }
+
+    return $tasks;
+  }
+
+  /**
+   * Helper function to get files from Pantheon.
+   */
+  private function getFilesPantheon(ConsoleIO $io, array $opts, $remotePlatform, $remoteSiteName, $remoteEnv, $origFilesFolder, $destFilesFolder) {
+    $tasks = $this->collectionBuilder($io);
+
+    if ($this->getCliToolStatus('terminus')) {
+      $filesName = 'site-files.tar.gz';
+      if (!$opts['no-overwrite']) {
+        $cmd = "wget `terminus backup:get $remoteSiteName.$remoteEnv --element=files` -O $origFilesFolder/$filesName";
+        $this->taskExec($cmd)->run();
+      }
+
+      if (file_exists("$origFilesFolder/$filesName")) {
+        $tasks->addTask($this->taskExec("cd $origFilesFolder && tar xzvf $filesName"));
+        $tasks->addTask($this->taskExec("cp -a $origFilesFolder/files_$remoteEnv/* $destFilesFolder"));
+        $tasks->addTask($this->taskExec("rm -r $origFilesFolder/files_$remoteEnv"));
+      }
+      else {
+        return "The file '$filesName' doesn't exist.";
+      }
+    }
+    else {
+      return 'Terminus is not installed, please install and configure it: https://docs.pantheon.io/terminus/install';
+    }
 
     return $tasks;
   }

--- a/src/Robo/Plugin/Commands/GetFilesCommand.php
+++ b/src/Robo/Plugin/Commands/GetFilesCommand.php
@@ -11,7 +11,7 @@ use Robo\Robo;
 class GetFilesCommand extends FireCommandBase {
 
   /**
-   * Import database for local envs.
+   * Get files from remote site and put in the local env.
    *
    * Usage Example: fire local:files:get
    *
@@ -22,13 +22,6 @@ class GetFilesCommand extends FireCommandBase {
    * @param $args drush you would like to execute.
    */
   public function getFiles(ConsoleIO $io, array $args) {
-    return $this->run($io, $args);
-  }
-
-  /**
-   * Run both commands.
-   */
-  public function run(ConsoleIO $io, array $args) {
     $cmd = '';
     $remotePlatform = Robo::config()->get('remote_platform');
     $remoteSiteName = Robo::config()->get('remote_sitename');
@@ -51,7 +44,7 @@ class GetFilesCommand extends FireCommandBase {
           $cmd .= " && cd ../";
         }
         else {
-          return 'Terminus is not installed, please install and configure it: https://docs.acquia.com/acquia-cli/install/';
+          return 'Acquia CLI is not installed, please install and configure it: https://docs.acquia.com/acquia-cli/install/';
         }
         break;
       case 'pantheon':

--- a/src/Robo/Plugin/Commands/GetFilesCommand.php
+++ b/src/Robo/Plugin/Commands/GetFilesCommand.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Fire\Robo\Plugin\Commands;
+
+use Robo\Symfony\ConsoleIO;
+use Robo\Robo;
+
+/**
+ * Provides a command to get the files into local.
+ */
+class GetFilesCommand extends FireCommandBase {
+
+  /**
+   * Import database for local envs.
+   *
+   * Usage Example: fire local:files:get
+   *
+   * @command local:get-files
+   * @aliases get-files, files-get, getfiles, filesget, get_files, files_get, pull-files, pull_files, local:file:get, local:get:files
+   * @usage fire local:files:get
+   *
+   * @param $args drush you would like to execute.
+   */
+  public function getFiles(ConsoleIO $io, array $args) {
+    return $this->run($io, $args);
+  }
+
+  /**
+   * Run both commands.
+   */
+  public function run(ConsoleIO $io, array $args) {
+    $cmd = '';
+    $remotePlatform = Robo::config()->get('remote_platform');
+    $remoteSiteName = Robo::config()->get('remote_sitename');
+    $remoteEnv = Robo::config()->get('remote_canonical_env');
+    $origFilesFolder = $this->getlocalEnvRoot() . '/reference';
+    $destFilesFolder = $this->getDrupalRoot() . '/sites/default/files';
+    $tasks = $this->collectionBuilder($io);
+
+    if (!file_exists($origFilesFolder)) {
+      $tasks->addTask($this->_mkdir($origFilesFolder));
+    }
+
+    switch ($remotePlatform) {
+      case 'acquia':
+        if ($this->getCliToolStatus('acli')) {
+          $cmd = "cd $origFilesFolder";
+          $cmd .= " && acli pull:files $remoteSiteName.$remoteEnv default";
+          $cmd .= " && cp -a ./docroot/sites/default/files/* $destFilesFolder";
+          $cmd .= " && rm -r ./docroot";
+          $cmd .= " && cd ../";
+        }
+        else {
+          return 'Terminus is not installed, please install and configure it: https://docs.acquia.com/acquia-cli/install/';
+        }
+        break;
+      case 'pantheon':
+      default:
+        if ($this->getCliToolStatus('terminus')) {
+          $filesName = 'site-files.tar.gz';
+
+          $cmd = "cd $origFilesFolder";
+          $cmd .= " && wget `terminus backup:get $remoteSiteName.$remoteEnv --element=files` -O $filesName";
+          $cmd .= " && tar xzvf $filesName";
+          $cmd .= " && cp -a files_$remoteEnv/* $destFilesFolder";
+          $cmd .= " && rm -r files_$remoteEnv";
+          $cmd .= " && cd ../";
+        }
+        else {
+          return 'Terminus is not installed, please install and configure it: https://docs.pantheon.io/terminus/install';
+        }
+        break;
+    }
+    $tasks->addTask($this->taskExec("$cmd")->args($args));
+
+    return $tasks;
+  }
+
+}

--- a/src/Robo/Plugin/Commands/LocalBuildCommand.php
+++ b/src/Robo/Plugin/Commands/LocalBuildCommand.php
@@ -34,8 +34,7 @@ class LocalBuildCommand extends Tasks {
       $tasks->addTask($this->taskExec('fire local:import-db'));
     }
     if ($opts['get-files']) {
-      // Download Files from remote server.
-      echo('Command needs to define.');
+      $tasks->addTask($this->taskExec('fire local:get-files'));
     }
     // Deploy Drush Commands.
     $tasks->addTask($this->taskExec('fire local:build:drush-commands'));


### PR DESCRIPTION
## Ticket:

- [Create command local:files:get](https://app.clickup.com/t/860qfuvv2)

## Description:

- Implements the command get-files.
- Update the documentation.
- Include the command get-files into the command local:build.

## How to test:

- [ ] Create and configure a project with lando or ddev.
- [ ] Configure the environment parameters: `remote_platform`, `remote_sitename` and `remote_canonical_env`.
- [ ] Run the following command: `fire get-files` or `fire pull-files`.
- [ ] Then run the following command: `ls -lha web/sites/default/files` and check that the website's files were downloaded.