### PR TITLE
26 use npm ci instead of npm install

### DIFF
--- a/src/Robo/Plugin/Commands/BuildJsCommand.php
+++ b/src/Robo/Plugin/Commands/BuildJsCommand.php
@@ -24,7 +24,7 @@ class BuildJsCommand extends FireCommandBase {
     $root = preg_replace('(\/web|\/docroot)', '', $root);
     $tasks = $this->collectionBuilder($io);
     if (file_exists($root . '/.nvmrc') && getenv('NVM_DIR')) {
-      $command = 'export NVM_DIR=$HOME/.nvm && source $NVM_DIR/nvm.sh && cd ' . $root . ' && nvm install && npm install && cd -';
+      $command = 'export NVM_DIR=$HOME/.nvm && source $NVM_DIR/nvm.sh && cd ' . $root . ' && nvm install && npm ci && cd -';
       $tasks->addTask($this->taskExec($command)->printOutput(TRUE));
     }
     elseif (file_exists($root . '/package.json')) {

--- a/src/Robo/Plugin/Commands/BuildJsCommand.php
+++ b/src/Robo/Plugin/Commands/BuildJsCommand.php
@@ -24,7 +24,7 @@ class BuildJsCommand extends FireCommandBase {
     $root = preg_replace('(\/web|\/docroot)', '', $root);
     $tasks = $this->collectionBuilder($io);
     if (file_exists($root . '/.nvmrc') && getenv('NVM_DIR')) {
-      $command = 'export NVM_DIR=$HOME/.nvm && source $NVM_DIR/nvm.sh && cd ' . $root . ' && nvm install && npm ci && cd -';
+      $command = 'export NVM_DIR=$HOME/.nvm && . $NVM_DIR/nvm.sh && cd ' . $root . ' && nvm install && npm ci && cd -';
       $tasks->addTask($this->taskExec($command)->printOutput(TRUE));
     }
     elseif (file_exists($root . '/package.json')) {

--- a/src/Robo/Plugin/Commands/BuildThemeCommand.php
+++ b/src/Robo/Plugin/Commands/BuildThemeCommand.php
@@ -26,7 +26,7 @@ class BuildThemeCommand extends FireCommandBase {
     $npmCommand = Robo::config()->get('local_theme_build_script');
     $command = 'cd ' . $root . ' && npm ci && npm run ' . $npmCommand;
     if (file_exists($root . '/.nvmrc') && getenv('NVM_DIR')) {
-        $command = 'export NVM_DIR=$HOME/.nvm && source $NVM_DIR/nvm.sh && cd ' . $root . ' && nvm install && npm ci && npm run ' . $npmCommand;
+        $command = 'export NVM_DIR=$HOME/.nvm && . $NVM_DIR/nvm.sh && cd ' . $root . ' && nvm install && npm ci && npm run ' . $npmCommand;
     }
     $tasks->taskExec($command);
     return $tasks;

--- a/src/Robo/Plugin/Commands/BuildThemeCommand.php
+++ b/src/Robo/Plugin/Commands/BuildThemeCommand.php
@@ -24,9 +24,9 @@ class BuildThemeCommand extends FireCommandBase {
     $root = $this->getThemePath();
     $tasks = $this->collectionBuilder($io);
     $npmCommand = Robo::config()->get('local_theme_build_script');
-    $command = 'cd ' . $root . ' && npm install && npm run ' . $npmCommand;
+    $command = 'cd ' . $root . ' && npm ci && npm run ' . $npmCommand;
     if (file_exists($root . '/.nvmrc') && getenv('NVM_DIR')) {
-        $command = 'export NVM_DIR=$HOME/.nvm && source $NVM_DIR/nvm.sh && cd ' . $root . ' && nvm install && npm install && npm run ' . $npmCommand;
+        $command = 'export NVM_DIR=$HOME/.nvm && source $NVM_DIR/nvm.sh && cd ' . $root . ' && nvm install && npm ci && npm run ' . $npmCommand;
     }
     $tasks->taskExec($command);
     return $tasks;


### PR DESCRIPTION
## Description:
- Use npm ci instead of npm install.
- Use '.' instead of 'source' when you are using 'bin/sh'.