### PR TITLE
Initial VRT implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,29 @@ Example:
 
     Alias: `xd-en`
 
+  - `vrt:generate-backstop-config`: Creates a basic Backstop.json for you.
+
+    Alias: `vgc`
+
+  - `vrt:init`: Configure your local enviroment from scratch to use VRT testing (Lando only).
+
+    Alias: `vinit`
+
+  - `vrt:local-env-config`: Alters your local enviroment so you can use backstop (Lando only).
+
+    Alias: `vlec`
+
+  - `vrt:reference`: Takes new reference screeshots from the reference URL (Lando only).
+
+    Alias: `vref`
+
+  - `vrt:run`: Runs your VRT testing (Lando only).
+
+    Alias: `vrun`
+
+  - `vrt:testing-setup`: Setups the Testing and reference sites for VRT testing.
+    Alias: `vts`
+
 
 ## Configuration
 Into your project root create a file called: `fire.yml` and iside of it speficify your global project settings.

--- a/assets/templates/backstop.json
+++ b/assets/templates/backstop.json
@@ -1,0 +1,79 @@
+{
+  "###NOTE###": "Don't edit backstop.json directly (unless making changes that everyone should use).  Instead copy as backstop-local.json.  See README.md for more info.",
+  "id": "site",
+  "viewports": [
+    {
+      "label": "phone",
+      "width": 320,
+      "height": 480
+    },
+    {
+      "label": "tablet",
+      "width": 768,
+      "height": 960
+    },
+    {
+      "label": "desktop",
+      "width": 1280,
+      "height": 768
+    }
+  ],
+  "onBeforeScript": "puppet/onBefore.js",
+  "onReadyScript": "puppet/onReady.js",
+  "scenarios": [
+    {
+      "label": "Batch1: Homepage — initial viewport",
+      "url": "/",
+      "referenceUrl": "/",
+     "_NOTE_": "Delay for the homepage hero to slide up. AND to get popup to finish rendering.",
+      "delay": 1500,
+      "postInteractionWait": 2000,
+      "selectors": ["viewport"]
+    },
+    {
+      "label": "Batch1: Homepage — full",
+      "url": "/?quotable_random=0",
+      "referenceUrl": "/?quotable_random=0",
+      "delay": 1500
+    },
+    {
+      "@todo": "This one is sometimes broken: The screenshot is taken of the viewport before the menu is open.",
+      "label": "Batch1: Homepage — open navigation (mobile) (not yet working)",
+      "url": "/",
+      "referenceUrl": "/",
+      "delay": 3600,
+      "onReadyScript": "initializePageMobile.js",
+      "@todo2": "This isn't working quite yet.  Also, due to limitations with selectors, we would need a class/ID on the +/- buttons in order to see the tree expanded.",
+      "clickSelectors": [
+        ".header__offcanvas-trigger"
+      ],
+      "postInteractionWait": 2000,
+      "selectors": ["viewport"],
+      "viewports": [
+        {
+          "label": "phone",
+          "width": 320,
+          "height": 640
+        }
+      ]
+    }
+  ],
+
+  "paths": {
+    "bitmaps_reference": "../../web/backstop/bitmaps_reference",
+    "bitmaps_test": "../../web/backstop/bitmaps_test",
+    "engine_scripts": "../../web/backstop/engine_scripts",
+    "html_report": "../../web/backstop/html_report",
+    "ci_report": "../../web/backstop/ci_report"
+  },
+  "report": ["CI", "browser"],
+  "engine": "puppeteer",
+  "engineOptions": {
+    "args": ["--no-sandbox"]
+  },
+  "mergeImgHack": true,
+  "asyncCaptureLimit": 3,
+  "asyncCompareLimit": 5,
+  "debug": false,
+  "debugWindow": false
+}

--- a/src/Robo/Plugin/Commands/VrtGenbackstopConfCommand.php
+++ b/src/Robo/Plugin/Commands/VrtGenbackstopConfCommand.php
@@ -27,8 +27,8 @@ class VrtGenbackstopConfCommand extends FireCommandBase {
       $tasks->addTask($this->taskFilesystemStack()->mkdir($this->getLocalEnvRoot() . '/tests/backstop'));
     }
     if ($env == 'lando') {
-      $override = $io->ask("This action Will create/override the following files:\n /tests/backstop/backstop.json Do you want to continue? (Y|N)");
-      if (preg_match('/^[Yy]{1}$/', $override, $matches)) {
+      $override = $io->confirm("This action Will create/override the following files:\n /tests/backstop/backstop.json Do you want to continue?", TRUE);
+      if ($override) {
         $tasks->addTask($this->taskFilesystemStack()->copy($assets . 'backstop.json', $this->getLocalEnvRoot() . '/tests/backstop/backstop.json'));
         $tasks->addTask($this->taskFilesystemStack()->copy($assets . 'backstop.json', $this->getLocalEnvRoot() . '/tests/backstop/backstop-local.json'));
       }

--- a/src/Robo/Plugin/Commands/VrtGenbackstopConfCommand.php
+++ b/src/Robo/Plugin/Commands/VrtGenbackstopConfCommand.php
@@ -33,6 +33,13 @@ class VrtGenbackstopConfCommand extends FireCommandBase {
         $tasks->addTask($this->taskFilesystemStack()->copy($assets . 'backstop.json', $this->getLocalEnvRoot() . '/tests/backstop/backstop-local.json'));
       }
     }
+    // Adding new lines to .gitignore,
+    $tasks->addTask($this->taskWriteToFile($this->getLocalEnvRoot() . '/.gitignore')
+      ->textFromFile($this->getLocalEnvRoot() . '/.gitignore')
+      ->appendUnlessMatches('/# FIRE VRT testing/', "# FIRE VRT testing\n")
+      ->appendUnlessMatches('/tests\/backstop\/backstop-local\.json/', "tests/backstop/backstop-local.json\n")
+      ->appendUnlessMatches('/web\/backstop\/\*/', "web/backstop/*")
+    );
 
     return $tasks;
   }

--- a/src/Robo/Plugin/Commands/VrtGenbackstopConfCommand.php
+++ b/src/Robo/Plugin/Commands/VrtGenbackstopConfCommand.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Fire\Robo\Plugin\Commands;
+
+use Robo\Symfony\ConsoleIO;
+use Robo\Robo;
+
+/**
+ * Provides a command to generate the Backstop initial files.
+ */
+class VrtGenbackstopConfCommand extends FireCommandBase {
+
+  /**
+   * Creates a basic Backstop.json for you.
+   *
+   * Usage Example: fire vrt:generate-backstop-config
+   *
+   * @command vrt:generate-backstop-config
+   * @aliases vgenbsconf
+   *
+   */
+  public function vrtGenBackstopConf(ConsoleIO $io) {
+    $env = Robo::config()->get('local_environment');
+    $tasks = $this->collectionBuilder($io);
+    $assets = dirname(__DIR__, 4) . '/assets/templates/';
+    if (!file_exists($this->getLocalEnvRoot() . '/tests/backstop')) {
+      $tasks->addTask($this->taskFilesystemStack()->mkdir($this->getLocalEnvRoot() . '/tests/backstop'));
+    }
+    if ($env == 'lando') {
+      $override = $io->ask("This action Will create/override the following files:\n /tests/backstop/backstop.json Do you want to continue? (Y|N)");
+      if (preg_match('/^[Yy]{1}$/', $override, $matches)) {
+        $tasks->addTask($this->taskFilesystemStack()->copy($assets . 'backstop.json', $this->getLocalEnvRoot() . '/tests/backstop/backstop.json'));
+        $tasks->addTask($this->taskFilesystemStack()->copy($assets . 'backstop.json', $this->getLocalEnvRoot() . '/tests/backstop/backstop-local.json'));
+      }
+    }
+
+    return $tasks;
+  }
+}

--- a/src/Robo/Plugin/Commands/VrtGenbackstopConfCommand.php
+++ b/src/Robo/Plugin/Commands/VrtGenbackstopConfCommand.php
@@ -16,7 +16,7 @@ class VrtGenbackstopConfCommand extends FireCommandBase {
    * Usage Example: fire vrt:generate-backstop-config
    *
    * @command vrt:generate-backstop-config
-   * @aliases vgenbsconf
+   * @aliases vgc
    *
    */
   public function vrtGenBackstopConf(ConsoleIO $io) {

--- a/src/Robo/Plugin/Commands/VrtLocalEnvConfigureCommand.php
+++ b/src/Robo/Plugin/Commands/VrtLocalEnvConfigureCommand.php
@@ -25,7 +25,6 @@ class VrtLocalEnvConfigureCommand extends FireCommandBase {
     $tasks = $this->collectionBuilder($io);
     if ($env == 'lando') {
       $landoConfig = Yaml::parse(file_get_contents($this->getLocalEnvRoot() . '/.lando.yml'));
-     // var_dump($landoConfig);
       if (!isset($landoConfig['services']['backstopserver'])) {
         $landoConfig['services']['backstopserver'] = [
           'type' => 'node',

--- a/src/Robo/Plugin/Commands/VrtLocalEnvConfigureCommand.php
+++ b/src/Robo/Plugin/Commands/VrtLocalEnvConfigureCommand.php
@@ -35,7 +35,7 @@ class VrtLocalEnvConfigureCommand extends FireCommandBase {
           'run' => 'rm -rf /app/web/backstop/bitmaps_test/*',
         ];
         $landoYamlDump = Yaml::dump($landoConfig, 5, 2);
-        file_put_contents($this->getLocalEnvRoot() . '/.lando.yml', $landoYmalDump);
+        file_put_contents($this->getLocalEnvRoot() . '/.lando.yml', $landoYamlDump);
         $tasks->addTask($this->taskExec('lando rebuild -y'));
       }
     }

--- a/src/Robo/Plugin/Commands/VrtLocalEnvConfigureCommand.php
+++ b/src/Robo/Plugin/Commands/VrtLocalEnvConfigureCommand.php
@@ -34,7 +34,7 @@ class VrtLocalEnvConfigureCommand extends FireCommandBase {
           ],
           'run' => 'rm -rf /app/web/backstop/bitmaps_test/*',
         ];
-        $landoYmalDump = Yaml::dump($landoConfig, 5);
+        $landoYamlDump = Yaml::dump($landoConfig, 5, 2);
         file_put_contents($this->getLocalEnvRoot() . '/.lando.yml', $landoYmalDump);
         $tasks->addTask($this->taskExec('lando rebuild -y'));
       }

--- a/src/Robo/Plugin/Commands/VrtLocalEnvConfigureCommand.php
+++ b/src/Robo/Plugin/Commands/VrtLocalEnvConfigureCommand.php
@@ -14,10 +14,10 @@ class VrtLocalEnvConfigureCommand extends FireCommandBase {
   /**
    * Runs your VRT testing over you local env.
    *
-   * Usage Example: fire vrt:local-config
+   * Usage Example: fire vrt:local-env-config
    *
-   * @command vrt:local-config
-   * @aliases vlocalconf
+   * @command vrt:local-env-config
+   * @aliases vlec
    *
    */
   public function vrtLocalEnvConfigure(ConsoleIO $io) {

--- a/src/Robo/Plugin/Commands/VrtLocalEnvConfigureCommand.php
+++ b/src/Robo/Plugin/Commands/VrtLocalEnvConfigureCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Fire\Robo\Plugin\Commands;
+
+use Robo\Symfony\ConsoleIO;
+use Robo\Robo;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Provides a command to build all php dependencies.
+ */
+class VrtLocalEnvConfigureCommand extends FireCommandBase {
+
+  /**
+   * Runs your VRT testing over you local env.
+   *
+   * Usage Example: fire vrt:local-config
+   *
+   * @command vrt:local-config
+   * @aliases vlocalconf
+   *
+   */
+  public function vrtLocalEnvConfigure(ConsoleIO $io) {
+    $env = Robo::config()->get('local_environment');
+    $tasks = $this->collectionBuilder($io);
+    if ($env == 'lando') {
+      $landoConfig = Yaml::parse(file_get_contents($this->getLocalEnvRoot() . '/.lando.yml'));
+     // var_dump($landoConfig);
+      if (!isset($landoConfig['services']['backstopserver'])) {
+        $landoConfig['services']['backstopserver'] = [
+          'type' => 'node',
+          'overrides' => [
+            'image' => 'backstopjs/backstopjs:6.3.1',
+            'shm_size' => '2gb',
+          ],
+          'run' => 'rm -rf /app/web/backstop/bitmaps_test/*',
+        ];
+        $landoYmalDump = Yaml::dump($landoConfig, 5);
+        file_put_contents($this->getLocalEnvRoot() . '/.lando.yml', $landoYmalDump);
+        $tasks->addTask($this->taskExec('lando rebuild -y'));
+      }
+    }
+
+    return $tasks;
+  }
+}

--- a/src/Robo/Plugin/Commands/VrtLocalEnvConfigureCommand.php
+++ b/src/Robo/Plugin/Commands/VrtLocalEnvConfigureCommand.php
@@ -7,12 +7,12 @@ use Robo\Robo;
 use Symfony\Component\Yaml\Yaml;
 
 /**
- * Provides a command to build all php dependencies.
+ * Provides a command to Alters your Local env so you can use VRT.
  */
 class VrtLocalEnvConfigureCommand extends FireCommandBase {
 
   /**
-   * Runs your VRT testing over you local env.
+   * Alters your local enviroment so you can use backstop (Lando only).
    *
    * Usage Example: fire vrt:local-env-config
    *

--- a/src/Robo/Plugin/Commands/VrtReferenceCommand.php
+++ b/src/Robo/Plugin/Commands/VrtReferenceCommand.php
@@ -11,7 +11,7 @@ use Robo\Robo;
 class VrtReferenceCommand extends FireCommandBase {
 
   /**
-   * Runs your VRT testing over you local env.
+   * Takes new reference screeshots from the reference URL (lando only).
    *
    * Usage Example: fire vref
    *

--- a/src/Robo/Plugin/Commands/VrtReferenceCommand.php
+++ b/src/Robo/Plugin/Commands/VrtReferenceCommand.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Fire\Robo\Plugin\Commands;
+
+use Robo\Symfony\ConsoleIO;
+use Robo\Robo;
+
+/**
+ * Provides to generate the reference files for backstop.
+ */
+class VrtReferenceCommand extends FireCommandBase {
+
+  /**
+   * Runs your VRT testing over you local env.
+   *
+   * Usage Example: fire vref
+   *
+   * @command vrt:reference
+   * @aliases vref
+   *
+   */
+  public function vrtReference(ConsoleIO $io) {
+    $env = Robo::config()->get('local_environment');
+    $tasks = $this->collectionBuilder($io);
+    if ($env == 'lando') {
+      $tasks->addTask($this->taskExec( $env . ' ssh -s backstopserver -c "cd /app/tests/backstop && backstop reference --config=/app/tests/backstop/backstop-local.json"'));
+    }
+
+    return $tasks;
+  }
+}

--- a/src/Robo/Plugin/Commands/VrtRunCommand.php
+++ b/src/Robo/Plugin/Commands/VrtRunCommand.php
@@ -24,12 +24,12 @@ class VrtRunCommand extends FireCommandBase {
     $env = Robo::config()->get('local_environment');
     $tasks = $this->collectionBuilder($io);
     if ($env == 'lando') {
-      $reconfigureTestingUrls = $io->choice('Do you want yo reconfigure your reference and test urls?', ['Yes', 'No']);
-      $newReferenceFiles = $io->choice('Do you want to re-take the reference screenshots?', ['Yes', 'No']);
-      if (strtolower($reconfigureTestingUrls) === 'yes') {
+      $reconfigureTestingUrls = $io->confirm('Do you want to reconfigure your reference and test urls?', true);
+      $newReferenceFiles = $io->confirm('Do you want to re-take the reference screenshots?', true);
+      if ($reconfigureTestingUrls) {
         $tasks->addTask($this->taskExec('fire vrt:testing-setup'));
       }
-      if (strtolower($newReferenceFiles) === 'yes') {
+      if ($newReferenceFiles) {
         $tasks->addTask($this->taskExec('fire vrt:reference'));
       }
       $landoConfig = Yaml::parse(file_get_contents($this->getLocalEnvRoot() . '/.lando.yml'));

--- a/src/Robo/Plugin/Commands/VrtRunCommand.php
+++ b/src/Robo/Plugin/Commands/VrtRunCommand.php
@@ -22,22 +22,19 @@ class VrtRunCommand extends FireCommandBase {
    */
   public function vrtRun(ConsoleIO $io) {
     $env = Robo::config()->get('local_environment');
-    $tasks = $this->collectionBuilder($io);
     if ($env == 'lando') {
-      $reconfigureTestingUrls = $io->confirm('Do you want to reconfigure your reference and test urls?', true);
-      $newReferenceFiles = $io->confirm('Do you want to re-take the reference screenshots?', true);
+      $reconfigureTestingUrls = $io->confirm('Do you want to reconfigure your reference and test urls?', TRUE);
+      $newReferenceFiles = $io->confirm('Do you want to re-take the reference screenshots?', TRUE);
       if ($reconfigureTestingUrls) {
-        $tasks->addTask($this->taskExec('fire vrt:testing-setup'));
+        $this->taskExec('fire vrt:testing-setup')->run();
       }
       if ($newReferenceFiles) {
-        $tasks->addTask($this->taskExec('fire vrt:reference'));
+        $this->taskExec('fire vrt:reference')->run();
       }
       $landoConfig = Yaml::parse(file_get_contents($this->getLocalEnvRoot() . '/.lando.yml'));
 
-      $tasks->addTask($this->taskExec($env . ' ssh -s backstopserver -c "cd /app/tests/backstop && backstop test --config=/app/tests/backstop/backstop-local.json"'));
-      $tasks->addTask($this->taskOpenBrowser('https://' . $landoConfig['name'] . '.lndo.site/backstop/html_report/index.html'));
+      $this->taskExec($env . ' ssh -s backstopserver -c "cd /app/tests/backstop && backstop test --config=/app/tests/backstop/backstop-local.json"')->run();
+      $this->taskOpenBrowser('https://' . $landoConfig['name'] . '.lndo.site/backstop/html_report/index.html')->run();
     }
-
-    return $tasks;
   }
 }

--- a/src/Robo/Plugin/Commands/VrtRunCommand.php
+++ b/src/Robo/Plugin/Commands/VrtRunCommand.php
@@ -7,12 +7,12 @@ use Robo\Robo;
 use Symfony\Component\Yaml\Yaml;
 
 /**
- * Provides a command to build all php dependencies.
+ * Provides a command to run the VRT testing.
  */
 class VrtRunCommand extends FireCommandBase {
 
   /**
-   * Runs your VRT testing over you local env.
+   * Runs your VRT testing (lando Only)
    *
    * Usage Example: fire vrt-run
    *

--- a/src/Robo/Plugin/Commands/VrtRunCommand.php
+++ b/src/Robo/Plugin/Commands/VrtRunCommand.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Fire\Robo\Plugin\Commands;
+
+use Robo\Symfony\ConsoleIO;
+use Robo\Robo;
+
+/**
+ * Provides a command to build all php dependencies.
+ */
+class VrtRunCommand extends FireCommandBase {
+
+  /**
+   * Runs your VRT testing over you local env.
+   *
+   * Usage Example: fire vrt-run
+   *
+   * @command vrt:run
+   * @aliases vrt-run
+   *
+   */
+  public function vrtRun(ConsoleIO $io) {
+    $env = Robo::config()->get('local_environment');
+    $tasks = $this->collectionBuilder($io);
+    if ($env == 'lando') {
+      $tasks->addTask($this->taskExec($env . ' ssh -s backstopserver -c "backstop test --config=/app/tests/backstop/backstop-local.json"'));
+    }
+
+    return $tasks;
+  }
+}

--- a/src/Robo/Plugin/Commands/VrtRunCommand.php
+++ b/src/Robo/Plugin/Commands/VrtRunCommand.php
@@ -4,6 +4,7 @@ namespace Fire\Robo\Plugin\Commands;
 
 use Robo\Symfony\ConsoleIO;
 use Robo\Robo;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * Provides a command to build all php dependencies.
@@ -16,14 +17,25 @@ class VrtRunCommand extends FireCommandBase {
    * Usage Example: fire vrt-run
    *
    * @command vrt:run
-   * @aliases vrt-run
+   * @aliases vrun
    *
    */
   public function vrtRun(ConsoleIO $io) {
     $env = Robo::config()->get('local_environment');
     $tasks = $this->collectionBuilder($io);
     if ($env == 'lando') {
-      $tasks->addTask($this->taskExec($env . ' ssh -s backstopserver -c "backstop test --config=/app/tests/backstop/backstop-local.json"'));
+      $reconfigureTestingUrls = $io->choice('Do you want yo reconfigure your reference and test urls?', ['Yes', 'No']);
+      $newReferenceFiles = $io->choice('Do you want to re-take the reference screenshots?', ['Yes', 'No']);
+      if (strtolower($reconfigureTestingUrls) === 'yes') {
+        $tasks->addTask($this->taskExec('fire vrt:testing-setup'));
+      }
+      if (strtolower($newReferenceFiles) === 'yes') {
+        $tasks->addTask($this->taskExec('fire vrt:reference'));
+      }
+      $landoConfig = Yaml::parse(file_get_contents($this->getLocalEnvRoot() . '/.lando.yml'));
+
+      $tasks->addTask($this->taskExec($env . ' ssh -s backstopserver -c "cd /app/tests/backstop && backstop test --config=/app/tests/backstop/backstop-local.json"'));
+      $tasks->addTask($this->taskOpenBrowser('https://' . $landoConfig['name'] . '.lndo.site/backstop/html_report/index.html'));
     }
 
     return $tasks;

--- a/src/Robo/Plugin/Commands/VrtTestingSetupCommand.php
+++ b/src/Robo/Plugin/Commands/VrtTestingSetupCommand.php
@@ -38,7 +38,7 @@ class VrtTestingSetupCommand extends FireCommandBase {
       $test_domain = "https://$testEnviroment-$remoteSiteName.pantheonsite.io";
       $reference_domain = "https://$canonicalEnvOverride-$remoteSiteName.pantheonsite.io";
 
-      $cloneReferenceEnv = $io->choice('Do you want to Clone the database and files from ' . $canonicalEnvOverride . ' to your test env ' . $testEnviroment, ['Yes', 'No']);
+      $cloneReferenceEnv = $io->confirm('Do you want to Clone the database and files from ' . $canonicalEnvOverride . ' to your test env ' . $testEnviroment . '?', TRUE);
 
       $assets = dirname(__DIR__, 4) . '/assets/templates/';
       if (!file_exists($this->getLocalEnvRoot() . '/tests/backstop/backstop.json')) {
@@ -61,7 +61,7 @@ class VrtTestingSetupCommand extends FireCommandBase {
       );
 
       // If user wants to clone the reference into the test env.
-      if (strtolower($cloneReferenceEnv) === 'yes') {
+      if ($cloneReferenceEnv) {
         if ($this->getCliToolStatus('terminus')) {
           $tasks->addTask($this->taskExec("terminus env:clone-content $remoteSiteName.$canonicalEnvOverride $testEnviroment --cc --updatedb -y"));
           $tasks->addTask($this->taskExec("terminus drush $remoteSiteName.$testEnviroment -- cim -y"));

--- a/src/Robo/Plugin/Commands/VrtTestingSetupCommand.php
+++ b/src/Robo/Plugin/Commands/VrtTestingSetupCommand.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Fire\Robo\Plugin\Commands;
+
+use Robo\Symfony\ConsoleIO;
+use Robo\Robo;
+
+/**
+ * Setups the Testing and reference sites for VRT testing.
+ */
+class VrtTestingSetupCommand extends FireCommandBase {
+
+  /**
+   * Setups the Testing and reference sites for VRT testing.
+   *
+   * Usage Example: fire vrt:testing-setup
+   *
+   * @command vrt:testing-setup
+   * @aliases vtestingsetup
+   *
+   */
+  public function vrtTestingSetup(ConsoleIO $io) {
+    $remotePlatform = Robo::config()->get('remote_platform');
+    $remoteSiteName = Robo::config()->get('remote_sitename');
+    $remoteCanonicalEnv = Robo::config()->get('remote_canonical_env');
+
+    $tasks = $this->collectionBuilder($io);
+    if (strtolower($remotePlatform) === 'pantheon') {
+
+      $testEnviroment = $io->ask("What environment are you testing (typically a multidev or dev)?");
+      $testEnviroment = strtolower($testEnviroment);
+      $testEnviroment = trim($testEnviroment);
+
+      $canonicalEnvOverride = $io->ask('What is the reference environment (typically dev, test, live)?', $remoteCanonicalEnv);
+      $canonicalEnvOverride = strtolower($canonicalEnvOverride);
+      $canonicalEnvOverride = trim($canonicalEnvOverride);
+
+      $test_domain = "https://$testEnviroment-$remoteSiteName.pantheonsite.io";
+      $reference_domain = "https://$canonicalEnvOverride-$remoteSiteName.pantheonsite.io";
+
+      $cloneReferenceEnv = $io->choice('Do you want to Clone the database and files from ' . $canonicalEnvOverride . ' to your test env ' . $testEnviroment, ['Yes', 'No']);
+
+      $assets = dirname(__DIR__, 4) . '/assets/templates/';
+      if (!file_exists($this->getLocalEnvRoot() . '/tests/backstop/backstop.json')) {
+        $tasks->addTask($this->taskFilesystemStack()->copy($assets . 'backstop.json', $this->getLocalEnvRoot() . '/tests/backstop/backstop-local.json', TRUE));
+      }
+      else {
+        var_dump($this->getLocalEnvRoot());
+        $tasks->addTask($this->taskFilesystemStack()->copy($this->getLocalEnvRoot() . '/tests/backstop/backstop.json', $this->getLocalEnvRoot() . '/tests/backstop/backstop-local.json', TRUE));
+      }
+      // Replacing Source URL
+      $tasks->addTask(
+        $this->taskReplaceInFile($this->getLocalEnvRoot() . '/tests/backstop/backstop-local.json')
+          ->from('"url": "')
+          ->to('"url": "' . $test_domain)
+      );
+      // Replacing Reference url
+      $tasks->addTask(
+        $this->taskReplaceInFile($this->getLocalEnvRoot() . '/tests/backstop/backstop-local.json')
+        ->from('"referenceUrl": "')
+        ->to('"referenceUrl": "' . $reference_domain)
+      );
+
+      // If user wants to clone the reference into the test env.
+      if (strtolower($cloneReferenceEnv) === 'yes') {
+        if ($this->getCliToolStatus('terminus')) {
+          $tasks->addTask($this->taskExec("terminus env:clone-content $remoteSiteName.$canonicalEnvOverride $testEnviroment --cc --updatedb -y"));
+          $tasks->addTask($this->taskExec("terminus drush $remoteSiteName.$testEnviroment -- cim -y"));
+          $tasks->addTask($this->taskExec("terminus drush $remoteSiteName.$testEnviroment -- cr"));
+          $tasks->addTask($this->taskExec("terminus drush $remoteSiteName.$testEnviroment -- cim -y"));
+        }
+      }
+    }
+    return $tasks;
+  }
+}

--- a/src/Robo/Plugin/Commands/VrtTestingSetupCommand.php
+++ b/src/Robo/Plugin/Commands/VrtTestingSetupCommand.php
@@ -45,7 +45,7 @@ class VrtTestingSetupCommand extends FireCommandBase {
         $tasks->addTask($this->taskFilesystemStack()->copy($assets . 'backstop.json', $this->getLocalEnvRoot() . '/tests/backstop/backstop-local.json', TRUE));
       }
       else {
-        $tasks-s>addTask($this->taskFilesystemStack()->copy($this->getLocalEnvRoot() . '/tests/backstop/backstop.json', $this->getLocalEnvRoot() . '/tests/backstop/backstop-local.json', TRUE));
+        $tasks->addTask($this->taskFilesystemStack()->copy($this->getLocalEnvRoot() . '/tests/backstop/backstop.json', $this->getLocalEnvRoot() . '/tests/backstop/backstop-local.json', TRUE));
       }
       // Replacing Source URL
       $tasks->addTask(

--- a/src/Robo/Plugin/Commands/VrtTestingSetupCommand.php
+++ b/src/Robo/Plugin/Commands/VrtTestingSetupCommand.php
@@ -16,7 +16,7 @@ class VrtTestingSetupCommand extends FireCommandBase {
    * Usage Example: fire vrt:testing-setup
    *
    * @command vrt:testing-setup
-   * @aliases vtestingsetup
+   * @aliases vts
    *
    */
   public function vrtTestingSetup(ConsoleIO $io) {

--- a/src/Robo/Plugin/Commands/VrtTestingSetupCommand.php
+++ b/src/Robo/Plugin/Commands/VrtTestingSetupCommand.php
@@ -45,8 +45,7 @@ class VrtTestingSetupCommand extends FireCommandBase {
         $tasks->addTask($this->taskFilesystemStack()->copy($assets . 'backstop.json', $this->getLocalEnvRoot() . '/tests/backstop/backstop-local.json', TRUE));
       }
       else {
-        var_dump($this->getLocalEnvRoot());
-        $tasks->addTask($this->taskFilesystemStack()->copy($this->getLocalEnvRoot() . '/tests/backstop/backstop.json', $this->getLocalEnvRoot() . '/tests/backstop/backstop-local.json', TRUE));
+        $tasks-s>addTask($this->taskFilesystemStack()->copy($this->getLocalEnvRoot() . '/tests/backstop/backstop.json', $this->getLocalEnvRoot() . '/tests/backstop/backstop-local.json', TRUE));
       }
       // Replacing Source URL
       $tasks->addTask(

--- a/src/Robo/Plugin/Commands/VrtinitCommand.php
+++ b/src/Robo/Plugin/Commands/VrtinitCommand.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Fire\Robo\Plugin\Commands;
+
+use Robo\Symfony\ConsoleIO;
+use Robo\Robo;
+
+/**
+ * Provides a command to initialize VRT.
+ */
+class VrtinitCommand extends FireCommandBase {
+
+  /**
+   * Intialices VRT for your env.
+   *
+   * Usage Example: fire vrt:init
+   *
+   * @command vrt:init
+   * @aliases vinit
+   *
+   */
+  public function vrtInit(ConsoleIO $io) {
+    $env = Robo::config()->get('local_environment');
+    $tasks = $this->collectionBuilder($io);
+    if ($env == 'lando') {
+      $tasks->addTask($this->taskExec('fire fire vrt:local-env-config'));
+      $tasks->addTask($this->taskExec('fire vrt:generate-backstop-config'));
+    }
+
+    return $tasks;
+  }
+}

--- a/src/Robo/Plugin/Commands/VrtinitCommand.php
+++ b/src/Robo/Plugin/Commands/VrtinitCommand.php
@@ -11,7 +11,7 @@ use Robo\Robo;
 class VrtinitCommand extends FireCommandBase {
 
   /**
-   * Intialices VRT for your env.
+   * Configure your local enviroment from scratch to use VRT testing (Lando only).
    *
    * Usage Example: fire vrt:init
    *

--- a/src/Robo/Plugin/Commands/VrtinitCommand.php
+++ b/src/Robo/Plugin/Commands/VrtinitCommand.php
@@ -23,8 +23,8 @@ class VrtinitCommand extends FireCommandBase {
     $env = Robo::config()->get('local_environment');
     $tasks = $this->collectionBuilder($io);
     if ($env == 'lando') {
-      $tasks->addTask($this->taskExec('fire fire vrt:local-env-config'));
       $tasks->addTask($this->taskExec('fire vrt:generate-backstop-config'));
+      $tasks->addTask($this->taskExec('fire vrt:local-env-config'));
     }
 
     return $tasks;


### PR DESCRIPTION
How to test
- Install the new version of fire into a project that doesn't have VRT configure
- How to install: `composer require fourkitchens/fire:dev-feature/vrt-configure --dev`
- Once installed execute : `fire vinit` - It should  configure your lando env to use backstop
- Then Run `fire vrt:run` and Select the options to reconfigure the URLs and retake the screenshoots . For the Clone data options please be careful for now , select as test env the DEV envirment and as reference Env the Test Enviroment and confirm the clone logic is working as it should .
- The run script shoud open a browser showing the results .