### PR TITLE
Get a one time login URL for any environment 

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,10 @@ Example:
       **2. Full:** It replaces all existing code and allows you to write the command from scratch.
 
     You can also create a new command, just choice the "Custom" option at the prompt when it ask you for for the command you want to overwrite, then respond to the questions, now a new command should have been created in the custom path, by default only a task is added to cleans the Drupal cache, but from this file, you can add your custom tasks.
+  
+  - `platform:uli`: This command allows you to generate a one-time login URL for any environment hosted on Pantheon, Acquia, or Platform.sh.
+
+    Alias: `puli`
 
 ## Configuration
 Into your project root create a file called: `fire.yml` and iside of it speficify your global project settings.

--- a/src/Robo/Plugin/Commands/PlatformUliCommand.php
+++ b/src/Robo/Plugin/Commands/PlatformUliCommand.php
@@ -16,7 +16,7 @@ class PlatformUliCommand extends FireCommandBase {
    * Usage Example: fire platform:uli pr-123
    *
    * @command platform:uli
-   * @aliases uli
+   * @aliases puli
    * @usage fire platform:uli <env>
    *
    * @param $args The environment.

--- a/src/Robo/Plugin/Commands/PlatformUliCommand.php
+++ b/src/Robo/Plugin/Commands/PlatformUliCommand.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Fire\Robo\Plugin\Commands;
+
+use Robo\Symfony\ConsoleIO;
+use Robo\Robo;
+
+/**
+ * Provides a wrapper for Terminus, Acquia CLI, and Platform.sh CLI to get login URLs.
+ */
+class PlatformUliCommand extends FireCommandBase {
+
+  /**
+   * Get the login URL for a site and environment.
+   *
+   * Usage Example: fire platform:uli pr-123
+   *
+   * @command platform:uli
+   * @aliases uli
+   * @usage fire platform:uli <env>
+   *
+   * @param $args The environment.
+   */
+  public function uli(ConsoleIO $io, array $args) {
+    // Ensure the correct number of arguments are passed
+    if (count($args) < 1) {
+      $io->note('Usage: fire platform:uli <env>');
+      return;
+    }
+
+    // Assign environment variable directly from arguments
+    $env = $args[0]; // First argument: environment (e.g., pr-123)
+
+    // Get platform and site name information (Pantheon, Acquia, Platform.sh)
+    $platform = Robo::config()->get('remote_platform'); // Set in Robo config for your project
+    $remoteSiteName = Robo::config()->get('remote_sitename'); // Get the remote site name from the config
+
+    // Check CLI tool status
+    $cliStatus = $this->checkCliTools($platform);
+
+    if (!$cliStatus) {
+      $io->note('Required CLI tools are not installed or configured properly.');
+      return;
+    }
+
+    // Determine the command based on the platform
+    switch ($platform) {
+      case 'pantheon':
+        $command = "terminus drush $remoteSiteName.$env -- uli";
+        break;
+
+      case 'acquia':
+        $command = "acli drush $remoteSiteName.$env -- uli";
+        break;
+
+      case 'platformsh':
+        $command = "platform ssh --site=$remoteSiteName --env=$env drush uli";
+        break;
+
+      default:
+        $io->note('Unknown platform or missing configuration for platform detection.');
+        return;
+    }
+
+    // Execute the command
+    $tasks = $this->collectionBuilder($io);
+    $tasks->addTask($this->taskExec($command)->printOutput(TRUE));
+
+    return $tasks;
+  }
+
+  /**
+   * Checks if the necessary CLI tools are installed for the given platform.
+   *
+   * @param string $platform The platform (pantheon, acquia, platformsh).
+   *
+   * @return bool True if the CLI tools are found, false otherwise.
+   */
+  private function checkCliTools(string $platform) {
+    switch ($platform) {
+      case 'pantheon':
+        return $this->getCliToolStatus('terminus');
+      case 'acquia':
+        return $this->getCliToolStatus('acli');
+      case 'platformsh':
+        return $this->getCliToolStatus('platform');
+      default:
+        return false;
+    }
+  }
+}


### PR DESCRIPTION
### Description:

This PR adds a new platform:uli command to Fire, making it easy to get a one-time login URL for a site and its environment, no matter if it's on Pantheon, Acquia, or Platform.sh. Now, you just need to type fire platform:uli <env> (for example, fire platform:uli pr-123), and Fire takes care of the rest, without worrying about platform-specific commands (like Terminus, Acquia CLI, or Platform.sh CLI).

### What this change does:
- Supports Pantheon, Acquia, and Platform.sh.
- Automatically detects the platform and runs the correct command.
- Simplifies getting the login URL for any environment.
- Removes the need to switch between different platform CLI tools.