### PR TITLE
feat: many VRT improvements

### DIFF
--- a/assets/templates/backstop.json
+++ b/assets/templates/backstop.json
@@ -1,6 +1,8 @@
 {
-  "###NOTE###": "Don't edit backstop.json directly (unless making changes that everyone should use).  Instead copy as backstop-local.json.  See README.md for more info.",
+  "###NOTE###": "Edit backstop.json for changes that everyone should use.  Otherwise edit backstop-local.json.  See README.md for more info.",
   "id": "site",
+  "testEnvironment": "",
+  "referenceEnvironment": "",
   "viewports": [
     {
       "label": "phone",

--- a/assets/templates/get-logged-in-cookie.example.sh
+++ b/assets/templates/get-logged-in-cookie.example.sh
@@ -36,14 +36,21 @@ cookie_value=$(echo "$session_cookie" | cut -d "=" -f 2)
 
 if [ "$1" == "local" ]; then
   # @todo consider getting a more robust URL via `ddev describe -j`
-  cookie_domain="$local_ddev_domain"
+  domain="$local_ddev_domain"
 elif [ "$1" == "live" ]; then
-  cookie_domain=".$live_domain"
+  domain="www.stern.nyu.edu"
 elif [[ " ${environments_with_custom_domains[*]} " =~ [[:space:]]${1}[[:space:]] ]]; then
-  cookie_domain=".www-$environment.stern.nyu.edu"
+  domain="www-$environment.stern.nyu.edu"
 else
-  cookie_domain=".$environment-$pantheon_site.pantheonsite.io"
+  domain="$environment-$pantheon_site.pantheonsite.io"
 fi
+
+# Hit a page with the session cookie to make the
+#   "You've just used your one-time login link..."
+# message to disappear.
+curl --silent --location  --output /dev/null --header "Cookie: $cookie_name=$cookie_value" --dump-header - "https://$domain/user"
+
+cookie_domain=".$domain"
 
 cookie_json='[{"domain":"'
 cookie_json+="$cookie_domain"

--- a/assets/templates/get-logged-in-cookie.example.sh
+++ b/assets/templates/get-logged-in-cookie.example.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+  echo "You must designate which environment to get a cookie for" >&2
+  echo "  e.g. get-logged-in-cookies dev" >&2
+  exit 2
+fi
+
+# Configuration.
+pantheon_site="nyu-stern-d9"
+environment="$1"
+environments_with_custom_domains=('test' 'develop' 'fast' 'freeze' 'feedback')
+local_ddev_domain="nyu-stern.ddev.site"
+live_domain="www.stern.nyu.edu"
+cookie_output_file="../../web/backstop_data/engine_scripts/cookies-uid1.json"
+# End of configuration.
+
+# Get the URL to log in.
+# @todo Consider getting separate cookies for multiple user roles.
+if [ "$environment" == "local" ]; then
+  uli_url=$(ddev drush user:login -l "$local_ddev_domain")
+else
+  uli_url=$(terminus drush "$pantheon_site"."$environment" -- user:login)
+fi
+
+# Get HTTP response headers when hitting that URL.
+http_headers=$(curl --silent --location --output /dev/null --dump-header - "$uli_url")
+
+# Only get the session cookie
+session_cookie=$(echo "$http_headers" | grep 'set-cookie:' | grep --only-matching 'S\?SESS[^;]*' | head -n1)
+echo "Found cookie" >&2
+echo "  $session_cookie"  >&2
+
+cookie_name=$(echo "$session_cookie" | cut -d "=" -f 1)
+cookie_value=$(echo "$session_cookie" | cut -d "=" -f 2)
+
+if [ "$1" == "local" ]; then
+  # @todo consider getting a more robust URL via `ddev describe -j`
+  cookie_domain="$local_ddev_domain"
+elif [ "$1" == "live" ]; then
+  cookie_domain=".$live_domain"
+elif [[ " ${environments_with_custom_domains[*]} " =~ [[:space:]]${1}[[:space:]] ]]; then
+  cookie_domain=".www-$environment.stern.nyu.edu"
+else
+  cookie_domain=".$environment-$pantheon_site.pantheonsite.io"
+fi
+
+cookie_json='[{"domain":"'
+cookie_json+="$cookie_domain"
+cookie_json+='","path":"/","name":"'
+cookie_json+="$cookie_name"
+cookie_json+='","value":"'
+cookie_json+="$cookie_value"
+cookie_json+='","expirationDate":1798790400,"hostOnly":false,"httpOnly":true,"secure":true,"session":false,"sameSite":"Lax"}]'
+
+parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+cd "$parent_path"
+touch $cookie_output_file
+echo "$cookie_json" > $cookie_output_file

--- a/assets/templates/get-logged-in-cookie.example.sh
+++ b/assets/templates/get-logged-in-cookie.example.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+#
+# Gets session cookies for logged in users for use with BackstopJS.  
+#
+# To use in a VRT scenario use something like
+#  "cookiePath": "../../web/backstop_data/engine_scripts/cookies-uid1.json"
 
 if [ -z "$1" ]; then
   echo "You must designate which environment to get a cookie for" >&2
@@ -8,12 +13,14 @@ fi
 
 # Configuration.
 pantheon_site="nyu-stern-d9"
-environment="$1"
-environments_with_custom_domains=('test' 'develop' 'fast' 'freeze' 'feedback')
+cookie_output_file="../../web/backstop_data/engine_scripts/cookies-uid1.json"
 local_ddev_domain="nyu-stern.ddev.site"
 live_domain="www.stern.nyu.edu"
-cookie_output_file="../../web/backstop_data/engine_scripts/cookies-uid1.json"
+# To use these you'll also need to adjust the code below to follow some pattern for the custom domains.
+environments_with_custom_domains=('test' 'develop' 'fast' 'freeze' 'feedback')
 # End of configuration.
+
+environment="$1"
 
 # Get the URL to log in.
 # @todo Consider getting separate cookies for multiple user roles.
@@ -48,7 +55,7 @@ fi
 # Hit a page with the session cookie to make the
 #   "You've just used your one-time login link..."
 # message to disappear.
-curl --silent --location  --output /dev/null --header "Cookie: $cookie_name=$cookie_value" --dump-header - "https://$domain/user"
+curl --silent --location  --output /dev/null --header "Cookie: $cookie_name=$cookie_value" "https://$domain/user"
 
 cookie_domain=".$domain"
 

--- a/src/Robo/Plugin/Commands/VrtBase.php
+++ b/src/Robo/Plugin/Commands/VrtBase.php
@@ -86,6 +86,9 @@ class VrtBase extends FireCommandBase {
     $configFile = $this->getLocalEnvRoot() . '/tests/backstop/backstop-local.json';
     $configContents = file_get_contents($configFile);
     $config = json_decode($configContents);
+    if (empty($config)) {
+      throw new AbortTasksException("The config file $configFile could not be parsed.  Maybe there's a JSON syntax error?");
+    }
     if ($backstopCommand === 'reference') {
       $key = 'referenceEnvironment';
     }
@@ -95,7 +98,7 @@ class VrtBase extends FireCommandBase {
     if (isset($config->{$key}) && is_string($config->{$key}) && $config->{$key}) {
       return $config->{$key};
     }
-    throw new AbortTasksException("$key was not found in $configFile.  These will be filled automatically by FIRE as long as they exist in backstop.json as just \"testEnvironment\": \"\",");
+    throw new AbortTasksException("$key was not found in $configFile.  These will be filled automatically by FIRE as long as they exist in backstop.json as just \"$key\": \"\",");
   }
 
 }

--- a/src/Robo/Plugin/Commands/VrtBase.php
+++ b/src/Robo/Plugin/Commands/VrtBase.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Fire\Robo\Plugin\Commands;
+
+use Ramsey\Collection\Exception\OutOfBoundsException;
+use Robo\Common\TaskIO;
+use Robo\Exception\AbortTasksException;
+use Robo\Exception\TaskException;
+use Robo\Exception\TaskExitException;
+use Robo\Symfony\ConsoleIO;
+use Robo\Robo;
+
+/**
+ * Provides shared methods used by many vrt commands.
+ */
+class VrtBase extends FireCommandBase {
+
+  /**
+   * Similar to taskExec(), but for Backstop commands.
+   *
+   * @param ConsoleIO $io
+   *
+   * @param string $backstopCommand
+   *  E.g. 'reference', or 'test'
+   *
+   * @return \Robo\Collection\CollectionBuilder|\Robo\Task\Base\Exec
+   */
+  protected function backstopTaskExec(ConsoleIO $io, string $backstopCommand) {
+    try {
+      $io->info("Running Backstop command: $backstopCommand...");
+
+      $env = Robo::config()->get('local_environment');
+
+      if ($backstopCommand !== 'init') {
+        $hostingEnvironment = $this->getHostingEnvironment($backstopCommand);
+        $this->refreshCookies($hostingEnvironment);
+      }
+      if ($env === 'lando') {
+        $config = '/app/tests/backstop/backstop-local.json';
+        $command = 'cd /app/tests/backstop';
+        $command .= ' && backstop ' . $backstopCommand;
+        $command .= ' --config=' . $config;
+        return $this->taskExec( $env . ' ssh -s backstopserver -c "' . $command . '"');
+      }
+      elseif ($env === 'ddev') {
+        $config = '/src/backstop-local.json';
+        $command = 'backstop ' . $backstopCommand;
+        $command .= ' --config=' . $config;
+        return $this->taskExec($env . ' ' . $command);
+      }
+      throw new AbortTasksException('Unknown local environment.');
+    }
+    catch (\Exception $exception) {
+      // @todo For some reason if you only throw an exception nothing is printed
+      // to the CLI.
+      $io->error($exception->getMessage());
+      throw $exception;
+    }
+  }
+
+  /**
+   * Regenerate cookies for this hosting environment, if there's a script for it.
+   *
+   * @param string $environment
+   *
+   * @return void
+   */
+  protected function refreshCookies(string $environment) {
+    $shellScript = $this->getLocalEnvRoot()  . '/tests/backstop/get-logged-in-cookie.sh';
+    if (file_exists($shellScript)) {
+      $this->taskExec($shellScript . ' ' . $environment)->run();
+    }
+  }
+
+  /**
+   * What hosting environment are we working with for the given Backstop command.
+   *
+   * @param $backstopCommand
+   *
+   * @return string
+   *   E.g. 'live', or 'pr-24'
+   *
+   * @throws \Robo\Exception\AbortTasksException
+   */
+  protected function getHostingEnvironment($backstopCommand) {
+    $configFile = $this->getLocalEnvRoot() . '/tests/backstop/backstop-local.json';
+    $configContents = file_get_contents($configFile);
+    $config = json_decode($configContents);
+    if ($backstopCommand === 'reference') {
+      $key = 'referenceEnvironment';
+    }
+    else {
+      $key = 'testEnvironment';
+    }
+    if (isset($config->{$key}) && is_string($config->{$key}) && $config->{$key}) {
+      return $config->{$key};
+    }
+    throw new AbortTasksException("$key was not found in $configFile.  These will be filled automatically by FIRE as long as they exist in backstop.json as just \"testEnvironment\": \"\",");
+  }
+
+}

--- a/src/Robo/Plugin/Commands/VrtBase.php
+++ b/src/Robo/Plugin/Commands/VrtBase.php
@@ -16,6 +16,13 @@ use Robo\Robo;
 class VrtBase extends FireCommandBase {
 
   /**
+   * The IO object.
+   *
+   * @var ConsoleIO
+   */
+  protected $io;
+
+  /**
    * Similar to taskExec(), but for Backstop commands.
    *
    * @param ConsoleIO $io
@@ -26,8 +33,9 @@ class VrtBase extends FireCommandBase {
    * @return \Robo\Collection\CollectionBuilder|\Robo\Task\Base\Exec
    */
   protected function backstopTaskExec(ConsoleIO $io, string $backstopCommand) {
+    $this->io = $io;
     try {
-      $io->info("Running Backstop command: $backstopCommand...");
+      $this->io->info("Running Backstop command: $backstopCommand...");
 
       $env = Robo::config()->get('local_environment');
 
@@ -53,7 +61,7 @@ class VrtBase extends FireCommandBase {
     catch (\Exception $exception) {
       // @todo For some reason if you only throw an exception nothing is printed
       // to the CLI.
-      $io->error($exception->getMessage());
+      $this->io->error($exception->getMessage());
       throw $exception;
     }
   }
@@ -68,7 +76,11 @@ class VrtBase extends FireCommandBase {
   protected function refreshCookies(string $environment) {
     $shellScript = $this->getLocalEnvRoot()  . '/tests/backstop/get-logged-in-cookie.sh';
     if (file_exists($shellScript)) {
+      $this->io->info("Running cookie generation file at $shellScript.");
       $this->taskExec($shellScript . ' ' . $environment)->run();
+    }
+    else {
+      $this->io->info("No cookie generation file found at $shellScript.  You will only be able to run scenarios as an anonymous visitor.");
     }
   }
 

--- a/src/Robo/Plugin/Commands/VrtGenbackstopConfCommand.php
+++ b/src/Robo/Plugin/Commands/VrtGenbackstopConfCommand.php
@@ -32,6 +32,8 @@ class VrtGenbackstopConfCommand extends VrtBase {
       $tasks->addTask($this->taskFilesystemStack()->copy($assets . 'backstop.json', $this->getLocalEnvRoot() . '/tests/backstop/backstop-local.json'));
     }
 
+    $tasks->addTask($this->taskFilesystemStack()->copy($assets . 'get-logged-in-cookie.example.sh', $this->getLocalEnvRoot() . '/tests/backstop/get-logged-in-cookie.example.sh'));
+
     // Adding new lines to .gitignore,
     $tasks->addTask($this->taskWriteToFile($this->getLocalEnvRoot() . '/.gitignore')
       ->textFromFile($this->getLocalEnvRoot() . '/.gitignore')

--- a/src/Robo/Plugin/Commands/VrtGenbackstopConfCommand.php
+++ b/src/Robo/Plugin/Commands/VrtGenbackstopConfCommand.php
@@ -8,7 +8,7 @@ use Robo\Robo;
 /**
  * Provides a command to generate the Backstop initial files.
  */
-class VrtGenbackstopConfCommand extends FireCommandBase {
+class VrtGenbackstopConfCommand extends VrtBase {
 
   /**
    * Creates a basic Backstop.json for you.

--- a/src/Robo/Plugin/Commands/VrtLocalEnvConfigureCommand.php
+++ b/src/Robo/Plugin/Commands/VrtLocalEnvConfigureCommand.php
@@ -9,7 +9,7 @@ use Symfony\Component\Yaml\Yaml;
 /**
  * Provides a command to Alters your Local env so you can use VRT.
  */
-class VrtLocalEnvConfigureCommand extends FireCommandBase {
+class VrtLocalEnvConfigureCommand extends VrtBase {
 
   /**
    * Alters your local enviroment so you can use backstop.
@@ -36,14 +36,11 @@ class VrtLocalEnvConfigureCommand extends FireCommandBase {
       $landoYamlDump = Yaml::dump($landoConfig, 5, 2);
       file_put_contents($this->getLocalEnvRoot() . '/.lando.yml', $landoYamlDump);
       $this->taskExec('lando rebuild -y')->run();
-      $this->taskExec('lando ssh -s backstopserver -c "cd /app/web/ && backstop init"')->run();
-
     }
     elseif ($env === 'ddev') {
       $this->taskExec('ddev get fourkitchens/ddev-drupal-backstop')->run();
       $this->taskExec('ddev restart')->run();
-      $this->taskExec('ddev backstop init')->run();
-
     }
+    return $this->backstopTaskExec($io, 'init');
   }
 }

--- a/src/Robo/Plugin/Commands/VrtReferenceCommand.php
+++ b/src/Robo/Plugin/Commands/VrtReferenceCommand.php
@@ -8,7 +8,7 @@ use Robo\Robo;
 /**
  * Provides to generate the reference files for backstop.
  */
-class VrtReferenceCommand extends FireCommandBase {
+class VrtReferenceCommand extends VrtBase {
 
   /**
    * Takes new reference screeshots from the reference URL.
@@ -19,16 +19,7 @@ class VrtReferenceCommand extends FireCommandBase {
    * @aliases vref
    *
    */
-  public function vrtReference(ConsoleIO $io) {
-    $env = Robo::config()->get('local_environment');
-    $tasks = $this->collectionBuilder($io);
-    if ($env === 'lando') {
-      $tasks->addTask($this->taskExec( $env . ' ssh -s backstopserver -c "cd /app/tests/backstop && backstop reference --config=/app/tests/backstop/backstop-local.json"'));
-    }
-    elseif ($env === 'ddev') {
-      $tasks->addTask($this->taskExec($env . ' backstop reference'));
-    }
-
-    return $tasks;
+  public function vrtReference(ConsoleIO $io, array $args) {
+    return $this->backstopTaskExec($io, 'reference')->run();
   }
 }

--- a/src/Robo/Plugin/Commands/VrtRunCommand.php
+++ b/src/Robo/Plugin/Commands/VrtRunCommand.php
@@ -30,21 +30,17 @@ class VrtRunCommand extends VrtBase {
     if ($newReferenceFiles) {
       $this->taskExec($this->getFireExecutable() . ' vrt:reference')->run();
     }
+
+    $this->backstopTaskExec($io, 'test')->run();
+    // Sometimes there can be a slight delay before the files are available in the Docker container.
+    sleep(1);
     
     if ($env === 'lando') {
       $landoConfig = Yaml::parse(file_get_contents($this->getLocalEnvRoot() . '/.lando.yml'));
-      $this->backstopTaskExec($io, 'test')->run();
-      // Sometimes there can be a slight delay before the files are available in container.
-      sleep(1);
-      // @todo Only open the report if the test command was run successfully.
       $this->taskOpenBrowser('https://' . $landoConfig['name'] . '.lndo.site/backstop_data/html_report/index.html')->run();
     }
     elseif ($env === 'ddev') {
       $ddevConfig = Yaml::parse(file_get_contents($this->getLocalEnvRoot() . '/.ddev/config.yaml'));
-      $this->backstopTaskExec($io, 'test')->run();
-      // Sometimes there can be a slight delay before the files are available in container.
-      sleep(1);
-      // @todo Only open the report if the test command was run successfully.
       $this->taskOpenBrowser('https://' . $ddevConfig['name']. '.ddev.site/backstop_data/html_report/index.html')->run();
     }
   }

--- a/src/Robo/Plugin/Commands/VrtRunCommand.php
+++ b/src/Robo/Plugin/Commands/VrtRunCommand.php
@@ -36,6 +36,7 @@ class VrtRunCommand extends VrtBase {
       $this->backstopTaskExec($io, 'test')->run();
       // Sometimes there can be a slight delay before the files are available in container.
       sleep(1);
+      // @todo Only open the report if the test command was run successfully.
       $this->taskOpenBrowser('https://' . $landoConfig['name'] . '.lndo.site/backstop_data/html_report/index.html')->run();
     }
     elseif ($env === 'ddev') {
@@ -43,6 +44,7 @@ class VrtRunCommand extends VrtBase {
       $this->backstopTaskExec($io, 'test')->run();
       // Sometimes there can be a slight delay before the files are available in container.
       sleep(1);
+      // @todo Only open the report if the test command was run successfully.
       $this->taskOpenBrowser('https://' . $ddevConfig['name']. '.ddev.site/backstop_data/html_report/index.html')->run();
     }
   }

--- a/src/Robo/Plugin/Commands/VrtRunCommand.php
+++ b/src/Robo/Plugin/Commands/VrtRunCommand.php
@@ -9,7 +9,7 @@ use Symfony\Component\Yaml\Yaml;
 /**
  * Provides a command to run the VRT testing.
  */
-class VrtRunCommand extends FireCommandBase {
+class VrtRunCommand extends VrtBase {
 
   /**
    * Runs your VRT testing.
@@ -30,15 +30,21 @@ class VrtRunCommand extends FireCommandBase {
     if ($newReferenceFiles) {
       $this->taskExec($this->getFireExecutable() . ' vrt:reference')->run();
     }
+    
     if ($env === 'lando') {
       $landoConfig = Yaml::parse(file_get_contents($this->getLocalEnvRoot() . '/.lando.yml'));
-      $this->taskExec('lando ssh -s backstopserver -c "cd /app/tests/backstop && backstop test --config=/app/tests/backstop/backstop-local.json"')->run();
+      $this->backstopTaskExec($io, 'test')->run();
+      // Sometimes there can be a slight delay before the files are available in container.
+      sleep(1);
       $this->taskOpenBrowser('https://' . $landoConfig['name'] . '.lndo.site/backstop_data/html_report/index.html')->run();
     }
     elseif ($env === 'ddev') {
       $ddevConfig = Yaml::parse(file_get_contents($this->getLocalEnvRoot() . '/.ddev/config.yaml'));
-      $this->taskExec($env . ' backstop test')->run();
+      $this->backstopTaskExec($io, 'test')->run();
+      // Sometimes there can be a slight delay before the files are available in container.
+      sleep(1);
       $this->taskOpenBrowser('https://' . $ddevConfig['name']. '.ddev.site/backstop_data/html_report/index.html')->run();
     }
   }
+  
 }

--- a/src/Robo/Plugin/Commands/VrtTestingSetupCommand.php
+++ b/src/Robo/Plugin/Commands/VrtTestingSetupCommand.php
@@ -8,7 +8,7 @@ use Robo\Robo;
 /**
  * Setups the Testing and reference sites for VRT testing.
  */
-class VrtTestingSetupCommand extends FireCommandBase {
+class VrtTestingSetupCommand extends VrtBase {
 
   /**
    * Setups the Testing and reference sites for VRT testing.
@@ -47,6 +47,17 @@ class VrtTestingSetupCommand extends FireCommandBase {
       else {
         $tasks->addTask($this->taskFilesystemStack()->copy($this->getLocalEnvRoot() . '/tests/backstop/backstop.json', $this->getLocalEnvRoot() . '/tests/backstop/backstop-local.json', TRUE));
       }
+      // Add environment variables.
+      $tasks->addTask(
+        $this->taskReplaceInFile($this->getLocalEnvRoot() . '/tests/backstop/backstop-local.json')
+          ->from('"testEnvironment": "')
+          ->to('"testEnvironment": "' . $testEnviroment)
+      );
+      $tasks->addTask(
+        $this->taskReplaceInFile($this->getLocalEnvRoot() . '/tests/backstop/backstop-local.json')
+          ->from('"referenceEnvironment": "')
+          ->to('"referenceEnvironment": "' . $canonicalEnvOverride)
+      );
       // Replacing Source URL
       $tasks->addTask(
         $this->taskReplaceInFile($this->getLocalEnvRoot() . '/tests/backstop/backstop-local.json')
@@ -63,10 +74,8 @@ class VrtTestingSetupCommand extends FireCommandBase {
       // If user wants to clone the reference into the test env.
       if ($cloneReferenceEnv) {
         if ($this->getCliToolStatus('terminus')) {
-          $tasks->addTask($this->taskExec("terminus env:clone-content $remoteSiteName.$canonicalEnvOverride $testEnviroment --cc --updatedb -y"));
-          $tasks->addTask($this->taskExec("terminus drush $remoteSiteName.$testEnviroment -- cim -y"));
-          $tasks->addTask($this->taskExec("terminus drush $remoteSiteName.$testEnviroment -- cr"));
-          $tasks->addTask($this->taskExec("terminus drush $remoteSiteName.$testEnviroment -- cim -y"));
+          $tasks->addTask($this->taskExec("terminus env:clone-content $remoteSiteName.$canonicalEnvOverride $testEnviroment -y"));
+          $tasks->addTask($this->taskExec("terminus drush $remoteSiteName.$testEnviroment -- deploy -y"));
         }
       }
     }

--- a/src/Robo/Plugin/Commands/VrtinitCommand.php
+++ b/src/Robo/Plugin/Commands/VrtinitCommand.php
@@ -8,7 +8,7 @@ use Robo\Robo;
 /**
  * Provides a command to initialize VRT.
  */
-class VrtinitCommand extends FireCommandBase {
+class VrtinitCommand extends VrtBase {
 
   /**
    * Configure your local enviroment from scratch to use VRT testing.


### PR DESCRIPTION
- centralize how backstop commands are run
- store which environments are reference/test
- generate cookies for each environment
- use `drush deploy` rather than something custom
- addresses https://github.com/fourkitchens/fire/issues/76

Requires this change in the other project:
https://github.com/fourkitchens/ddev-drupal-backstop/pull/1