### PR TITLE
Address Robo Error in local:get-db Command

### DIFF
--- a/src/Robo/Plugin/Commands/GetDBCommand.php
+++ b/src/Robo/Plugin/Commands/GetDBCommand.php
@@ -30,7 +30,7 @@ class GetDBCommand extends FireCommandBase {
     $tasks = $this->collectionBuilder($io);
 
     if (!file_exists($dbFolder)) {
-      $tasks->addTask($this->_mkdir($dbFolder));
+      $tasks->addTask($this->taskFilesystemStack()->mkdir($dbFolder));
     }
 
     switch ($remotePlatform) {


### PR DESCRIPTION
This PR addresses the issue outlined in #82.

Testing steps:
- [ ] Delete the `./reference` directory from your local file system `rm -rf ./reference`
- [ ] Run the `fire setup -y` or `file local:build` commands on any local site and confirm there is no error produced during the first attempt at running the command
